### PR TITLE
fix(installer): use requirements.txt for backend dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -231,7 +231,11 @@ if [ "$INSTALL_DASHBOARD" = true ]; then
 
         BACKEND_DIR="$DASHBOARD_DST/backend"
         if [ -d "$BACKEND_DIR" ]; then
-            pip install -q fastapi uvicorn aiofiles websockets 2>&1 || pip3 install -q fastapi uvicorn aiofiles websockets 2>&1
+            if [ -f "$BACKEND_DIR/requirements.txt" ]; then
+                pip install -q -r "$BACKEND_DIR/requirements.txt" 2>&1 || pip3 install -q -r "$BACKEND_DIR/requirements.txt" 2>&1
+            else
+                pip install -q fastapi uvicorn aiofiles websockets aiosqlite python-dateutil 2>&1 || pip3 install -q fastapi uvicorn aiofiles websockets aiosqlite python-dateutil 2>&1
+            fi
             echo -e "  ${GREEN}Installed backend dependencies${NC}"
         fi
 


### PR DESCRIPTION
## Summary

The installer script (`install.sh`) was hardcoding a subset of backend dependencies instead of reading from `requirements.txt`. This caused `aiosqlite` and `python-dateutil` to not be installed, resulting in `ImportError` when starting the dashboard backend.

### The Problem

Line 234 in `install.sh` was:
```bash
pip install -q fastapi uvicorn aiofiles websockets
```

But `dashboard-app/backend/requirements.txt` includes:
```
fastapi>=0.115.0
uvicorn[standard]>=0.31.0
websockets>=15.0
aiosqlite>=0.20.0
python-dateutil>=2.8.0
```

### The Fix

- Prefer `requirements.txt` if it exists (proper approach)
- Fallback to updated hardcoded list including all dependencies

This ensures all dependencies are installed regardless of future additions to `requirements.txt`.

## Test Plan

1. Fresh install on a system without `aiosqlite` or `python-dateutil`
2. Run `./install.sh`
3. Start dashboard with `./run-dashboard.sh`
4. Verify backend starts without ImportError

Tested locally - dashboard now starts correctly after reinstallation.