### PR TITLE
docs(readme): add link to Getting Started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Claude Code learns from your failures and successes, building institutional know
 ./install.ps1             # Windows
 ```
 
+**New to ELF?** See the [Getting Started Guide](GETTING_STARTED.md) for detailed step-by-step instructions including prerequisites and troubleshooting.
+
 ## First Use: Say "check in"
 
 **Every session, start with `check in`.** This is the most important habit:
@@ -159,6 +161,8 @@ cd ~/.claude/emergent-learning/dashboard-app && ./run-dashboard.sh
 | **Creative** | Novel solutions, lateral thinking |
 
 ## Documentation
+
+**Quick Start:** [Getting Started Guide](GETTING_STARTED.md) - Step-by-step setup from zero to running
 
 Full documentation in the [Wiki](https://github.com/Spacehunterz/Emergent-Learning-Framework_ELF/wiki):
 


### PR DESCRIPTION
## Summary

The `GETTING_STARTED.md` guide exists with excellent step-by-step instructions for new users, but it wasn't linked from the README. This PR adds visibility to the guide.

## Changes

Added links to `GETTING_STARTED.md` in two places:

1. **After the Install section** - For users who see the quick install commands but need more detail
   ```markdown
   **New to ELF?** See the [Getting Started Guide](GETTING_STARTED.md) for detailed step-by-step instructions including prerequisites and troubleshooting.
   ```

2. **In the Documentation section** - As a "Quick Start" entry before the Wiki links
   ```markdown
   **Quick Start:** [Getting Started Guide](GETTING_STARTED.md) - Step-by-step setup from zero to running
   ```

## Why

The Getting Started guide covers:
- Prerequisites (Claude Code CLI, Python, Node.js/Bun)
- Download options (git clone vs ZIP)
- Installation with options explained
- Verification steps
- Troubleshooting common issues

New users benefit from finding this guide easily rather than diving straight into Wiki documentation.

## Test Plan

- [x] Links are valid relative paths
- [x] README renders correctly with new content