### PR TITLE
fix(hooks): add file operations tracking for trail/hotspot analysis

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -300,14 +300,14 @@ if 'PostToolUse' not in settings['hooks']:
     settings['hooks']['PostToolUse'] = []
 
 # Remove any existing ELF hooks (to avoid duplicates on reinstall)
-# Only remove hooks where matcher="Task" AND command contains "learning-loop"
+# Remove hooks where command contains "learning-loop"
 settings['hooks']['PreToolUse'] = [
     h for h in settings['hooks']['PreToolUse']
-    if not (h.get('matcher') == 'Task' and any('learning-loop' in hook.get('command', '') for hook in h.get('hooks', [])))
+    if not any('learning-loop' in hook.get('command', '') for hook in h.get('hooks', []))
 ]
 settings['hooks']['PostToolUse'] = [
     h for h in settings['hooks']['PostToolUse']
-    if not (h.get('matcher') == 'Task' and any('learning-loop' in hook.get('command', '') for hook in h.get('hooks', [])))
+    if not any('learning-loop' in hook.get('command', '') for hook in h.get('hooks', []))
 ]
 
 # Add ELF hooks - use python on Windows, python3 on Unix
@@ -325,6 +325,12 @@ settings['hooks']['PreToolUse'].append({
 
 settings['hooks']['PostToolUse'].append({
     "matcher": "Task",
+    "hooks": [{"type": "command", "command": f"{python_cmd} \"{post_hook}\""}]
+})
+
+# Add hook for file operations (trail tracking for hotspots)
+settings['hooks']['PostToolUse'].append({
+    "matcher": "Read|Edit|Write|Glob|Grep",
     "hooks": [{"type": "command", "command": f"{python_cmd} \"{post_hook}\""}]
 })
 


### PR DESCRIPTION
## Summary

Fixes #22 - The learning hook has logic to track file operations for trail/hotspot analysis, but the installer only configured it to trigger for Task tool calls.

## Problem

The `post_tool_learning.py` hook has code (lines 592-625) to track file operations:

```python
file_operation_tools = {'Read', 'Edit', 'Write', 'Glob', 'Grep'}
if tool_name in file_operation_tools:
    # Records trails to database for hotspot tracking
```

But the installer only configured:
```json
"PostToolUse": [{"matcher": "Task", ...}]
```

This meant:
- ❌ File operations never triggered the hook
- ❌ Trails table stayed empty
- ❌ Dashboard hotspots didn't populate
- ❌ Users thought nothing was being tracked

## Solution

Add a second PostToolUse hook entry for file operations:

```json
"PostToolUse": [
  {"matcher": "Task", ...},
  {"matcher": "Read|Edit|Write|Glob|Grep", ...}
]
```

## Changes

**install.sh (Unix/Mac):**
- Added file operations hook (lines 331-335)
- Updated cleanup logic to remove all learning-loop hooks on reinstall

**install.ps1 (Windows):**
- Added `$elfFileOpsHook` definition
- Added to PostToolUse array
- Updated cleanup logic similarly

## Test Plan

1. Fresh install on a system
2. Use Claude Code normally (edit files, read files, etc.)
3. Check database: `SELECT COUNT(*) FROM trails` should show entries
4. Dashboard hotspots treemap should populate

## Backward Compatibility

- Existing users will get the new hook on reinstall
- No breaking changes to existing functionality
- Cleanup logic updated to handle both old and new hook configurations