### PR TITLE
fix(dashboard): improve Cosmic view UX with multiple fixes

### DIFF
--- a/dashboard-app/frontend/src/App.tsx
+++ b/dashboard-app/frontend/src/App.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from 'react'
-import { ThemeProvider, NotificationProvider, useNotificationContext, DataProvider, useDataContext, CosmicSettingsProvider, CosmicAudioProvider, useCosmicSettings, useTheme } from './context'
-import { DashboardLayout } from './layouts/DashboardLayout'
+import { ThemeProvider, NotificationProvider, useNotificationContext, DataProvider, useDataContext } from './context'
 import { useWebSocket, useAPI } from './hooks'
-import CosmicIntro from './components/CosmicIntro'
 import {
+  SettingsPanel,
+  ParticleBackground,
+  Header,
   StatsBar,
   HotspotVisualization,
   HeuristicPanel,
@@ -12,6 +13,8 @@ import {
   QueryInterface,
   AlertsPanel,
   KnowledgeGraph,
+  CommandPalette,
+  NotificationPanel,
   LearningVelocity,
   SessionHistoryPanel,
   AssumptionsPanel,
@@ -21,6 +24,13 @@ import {
 } from './components'
 import {
   TimelineEvent,
+  Stats,
+  Heuristic,
+  Hotspot,
+  ApiRun,
+  ApiAnomaly,
+  TimelineData,
+  RawEvent
 } from './types'
 
 function AppContent() {
@@ -28,9 +38,6 @@ function AppContent() {
   const [selectedDomain, setSelectedDomain] = useState<string | null>(null)
   const [isConnected, setIsConnected] = useState(false)
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false)
-  // Intro disabled - set to true to re-enable
-  const [showIntro, setShowIntro] = useState(false)
-  const [introMode, setIntroMode] = useState<'full' | 'short'>('full')
 
   const api = useAPI()
   const notifications = useNotificationContext()
@@ -120,26 +127,14 @@ function AppContent() {
   // Command Palette keyboard shortcut
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Command Palette
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
         e.preventDefault()
         setCommandPaletteOpen(true)
       }
-
-      // Escape to clear selection / navigate back
-      if (e.key === 'Escape') {
-        if (selectedDomain) {
-          e.preventDefault()
-          setSelectedDomain(null)
-        } else if (activeTab !== 'overview') {
-          // Optional: Esc from other tabs could go back to overview?
-          // user only mentioned "drill down into a card... cant esc key out"
-        }
-      }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [selectedDomain, activeTab])
+  }, [])
 
   const handleRetryRun = async (runId: string) => {
     try {
@@ -157,33 +152,22 @@ function AppContent() {
     }
   }
 
-  const { performanceMode } = useCosmicSettings()
-  const { setParticleCount } = useTheme()
-
-  // Performance Mode Logic
-  useEffect(() => {
-    switch (performanceMode) {
-      case 'low': setParticleCount(50); break;
-      case 'medium': setParticleCount(100); break;
-      case 'high': setParticleCount(200); break;
-    }
-  }, [performanceMode, setParticleCount])
-
   // Convert stats to expected format for StatsBar
   // FIX: Use successful_runs/failed_runs from backend (actual workflow runs), not successes/failures (learnings)
   const statsForBar = stats ? {
     total_runs: stats.total_runs,
-    successful_runs: stats.successful_runs,
-    failed_runs: stats.failed_runs,
-    success_rate: stats.total_runs > 0 ? stats.successful_runs / stats.total_runs : 0,
+    successful_runs: stats.successful_runs,  // FIXED: was stats.successes (learning count)
+    failed_runs: stats.failed_runs,          // FIXED: was stats.failures (learning count)
+    success_rate: stats.total_runs > 0 ? stats.successful_runs / stats.total_runs : 0,  // FIXED: use run counts
     total_heuristics: stats.total_heuristics,
     golden_rules: stats.golden_rules,
     total_learnings: stats.total_learnings,
     hotspot_count: hotspots.length,
     avg_confidence: stats.avg_confidence,
     total_validations: stats.total_validations,
-    runs_today: stats.runs_today || 0,
+    runs_today: stats.runs_today || 0,       // FIXED: use runs_today from backend
     active_domains: new Set(heuristics.map(h => h.domain)).size,
+    // Query stats
     queries_today: stats.queries_today || 0,
     total_queries: stats.total_queries || 0,
     avg_query_duration_ms: stats.avg_query_duration_ms || 0,
@@ -198,65 +182,70 @@ function AppContent() {
   // Command palette commands
   const commands = [
     { id: 'overview', label: 'Go to Overview', category: 'Navigation', action: () => setActiveTab('overview') },
-    { id: 'graph', label: 'View Knowledge Graph', category: 'Navigation', action: () => setActiveTab('graph') },
-    { id: 'analytics', label: 'View Learning Analytics', category: 'Navigation', action: () => setActiveTab('analytics') },
-    { id: 'runs', label: 'View Runs', category: 'Navigation', action: () => setActiveTab('runs') },
-    { id: 'timeline', label: 'View Timeline', category: 'Navigation', action: () => setActiveTab('timeline') },
     { id: 'heuristics', label: 'View Heuristics', category: 'Navigation', action: () => setActiveTab('heuristics') },
     { id: 'assumptions', label: 'View Assumptions', category: 'Navigation', action: () => setActiveTab('assumptions') },
     { id: 'spikes', label: 'View Spike Reports', category: 'Navigation', action: () => setActiveTab('spikes') },
     { id: 'invariants', label: 'View Invariants', category: 'Navigation', action: () => setActiveTab('invariants') },
     { id: 'fraud', label: 'Review Fraud Reports', category: 'Navigation', action: () => setActiveTab('fraud') },
+    { id: 'graph', label: 'View Knowledge Graph', category: 'Navigation', action: () => setActiveTab('graph') },
+    { id: 'runs', label: 'View Runs', category: 'Navigation', action: () => setActiveTab('runs') },
+    { id: 'timeline', label: 'View Timeline', category: 'Navigation', action: () => setActiveTab('timeline') },
+    { id: 'analytics', label: 'View Learning Analytics', category: 'Navigation', action: () => setActiveTab('analytics') },
     { id: 'query', label: 'Query the Building', shortcut: '⌘Q', category: 'Actions', action: () => setActiveTab('query') },
     { id: 'refresh', label: 'Refresh Data', shortcut: '⌘R', category: 'Actions', action: () => { loadStats(); reloadHeuristics() } },
     { id: 'clearDomain', label: 'Clear Domain Filter', category: 'Actions', action: () => setSelectedDomain(null) },
     { id: 'toggleNotificationSound', label: notifications.soundEnabled ? 'Mute Notifications' : 'Unmute Notifications', category: 'Settings', action: notifications.toggleSound },
     { id: 'clearNotifications', label: 'Clear All Notifications', category: 'Actions', action: notifications.clearAll },
-    { id: 'playIntroFull', label: 'Play Intro (Full)', category: 'System', action: () => { setIntroMode('full'); setShowIntro(true); setCommandPaletteOpen(false); } },
-    { id: 'playIntroShort', label: 'Play Intro (Short)', category: 'System', action: () => { setIntroMode('short'); setShowIntro(true); setCommandPaletteOpen(false); } },
   ]
 
   return (
-    <>
-      <DashboardLayout
-        activeTab={activeTab}
-        onTabChange={(tab) => setActiveTab(tab as any)}
-        isConnected={isConnected}
-        commandPaletteOpen={commandPaletteOpen}
-        setCommandPaletteOpen={setCommandPaletteOpen}
+    <div className="min-h-screen relative overflow-hidden transition-colors duration-500" style={{ backgroundColor: "var(--theme-bg-primary)" }}>
+      <ParticleBackground />
+      <SettingsPanel />
+      <CommandPalette
+        isOpen={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
         commands={commands}
-        onDomainSelect={setSelectedDomain}
-        selectedDomain={selectedDomain}
-      >
-        {/* Intro Layer */}
-        {showIntro && (
-          <div className="fixed inset-0 z-[100000] bg-black">
-            <CosmicIntro
-              mode={introMode}
-              onComplete={() => setShowIntro(false)}
-            />
-          </div>
-        )}
+      />
+      <NotificationPanel
+        notifications={notifications.notifications}
+        onDismiss={notifications.removeNotification}
+        onClearAll={notifications.clearAll}
+        soundEnabled={notifications.soundEnabled}
+        onToggleSound={notifications.toggleSound}
+      />
+      <div className="relative z-10">
+        <Header
+          isConnected={isConnected}
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          onOpenCommandPalette={() => setCommandPaletteOpen(true)}
+        />
 
-        <div className="space-y-6">
-          {/* Stats Bar */}
-          <StatsBar stats={statsForBar} />
+      <main className="container mx-auto px-4 py-6">
+        {/* Stats Bar - Always visible */}
+        <StatsBar stats={statsForBar} />
 
-          {/* Tab Content */}
+        {/* Tab Content */}
+        <div className="mt-6">
           {activeTab === 'overview' && (
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Main area - Hotspot Visualization (Grid/Cosmic toggle) */}
               <div className="lg:col-span-2">
                 <HotspotVisualization
                   hotspots={hotspots}
-                  onSelect={(path) => handleOpenInEditor(path)}
+                  onSelect={() => {}} // Selection handled by cosmic store, editor opened via detail panel
+                  onOpenInEditor={handleOpenInEditor}
                   selectedDomain={selectedDomain}
                   onDomainFilter={setSelectedDomain}
                 />
               </div>
+
+              {/* Sidebar - Unified Alerts Panel */}
               <div className="space-y-6">
                 <AlertsPanel
                   anomalies={anomalies}
-                  goldenRules={normalizedHeuristics.filter(h => h.is_golden).map(h => ({ ...h, id: String(h.id) })) as any}
+                  goldenRules={normalizedHeuristics.filter(h => h.is_golden)}
                   onDismissAnomaly={(index) => setAnomalies(prev => prev.filter((_, i) => i !== index))}
                 />
               </div>
@@ -278,6 +267,7 @@ function AppContent() {
           {activeTab === 'graph' && (
             <KnowledgeGraph
               onNodeClick={(node) => {
+                // Optionally switch to heuristics tab and filter by domain
                 setSelectedDomain(node.domain)
               }}
             />
@@ -305,9 +295,13 @@ function AppContent() {
           )}
 
           {activeTab === 'sessions' && <SessionHistoryPanel />}
+
           {activeTab === 'assumptions' && <AssumptionsPanel />}
+
           {activeTab === 'spikes' && <SpikeReportsPanel />}
+
           {activeTab === 'invariants' && <InvariantsPanel />}
+
           {activeTab === 'fraud' && <FraudReviewPanel />}
 
           {activeTab === 'timeline' && (
@@ -323,17 +317,21 @@ function AppContent() {
                 domain: e.domain,
               }))}
               heuristics={normalizedHeuristics}
-              onEventClick={() => { }}
+              onEventClick={() => {}}
             />
           )}
 
-          {activeTab === 'query' && <QueryInterface />}
+          {activeTab === 'query' && (
+            <QueryInterface />
+          )}
 
-          {/* Analytics is handled by DashboardLayout for Cosmic mode, but we keep this for grid mode */}
-          {activeTab === 'analytics' && <LearningVelocity days={30} />}
+          {activeTab === 'analytics' && (
+            <LearningVelocity days={30} />
+          )}
         </div>
-      </DashboardLayout>
-    </>
+      </main>
+      </div>
+    </div>
   )
 }
 
@@ -342,11 +340,7 @@ function App() {
     <ThemeProvider>
       <NotificationProvider>
         <DataProvider>
-          <CosmicSettingsProvider>
-            <CosmicAudioProvider>
-              <AppContent />
-            </CosmicAudioProvider>
-          </CosmicSettingsProvider>
+          <AppContent />
         </DataProvider>
       </NotificationProvider>
     </ThemeProvider>

--- a/dashboard-app/frontend/src/components/cosmic-view/CosmicDetailPanel.tsx
+++ b/dashboard-app/frontend/src/components/cosmic-view/CosmicDetailPanel.tsx
@@ -4,9 +4,10 @@ import type { CelestialBody } from './types'
 interface CosmicDetailPanelProps {
   body: CelestialBody
   onClose: () => void
+  onOpenInEditor?: (path: string, line?: number) => void
 }
 
-export function CosmicDetailPanel({ body, onClose }: CosmicDetailPanelProps) {
+export function CosmicDetailPanel({ body, onClose, onOpenInEditor }: CosmicDetailPanelProps) {
   // Format recency as human readable
   const getRecencyLabel = (recency: number) => {
     if (recency > 0.8) return 'Very Recent'
@@ -58,7 +59,7 @@ export function CosmicDetailPanel({ body, onClose }: CosmicDetailPanelProps) {
   }
 
   return (
-    <div className="bg-slate-800/80 backdrop-blur-sm rounded-lg p-4 animate-in slide-in-from-bottom-2 duration-200 max-h-[80vh] overflow-y-auto custom-scrollbar">
+    <div className="bg-slate-800/80 backdrop-blur-sm rounded-lg p-4 animate-in slide-in-from-bottom-2 duration-200">
       {/* Header */}
       <div className="flex items-start justify-between mb-4">
         <div className="flex-1 min-w-0">
@@ -140,7 +141,10 @@ export function CosmicDetailPanel({ body, onClose }: CosmicDetailPanelProps) {
         <div className="text-xs text-slate-500">
           Directory: <span className="text-slate-400">{body.directory}</span>
         </div>
-        <button className="flex items-center gap-1 text-xs text-amber-400 hover:text-amber-300 transition-colors">
+        <button
+          onClick={() => onOpenInEditor?.(body.location)}
+          className="flex items-center gap-1 text-xs text-amber-400 hover:text-amber-300 transition-colors"
+        >
           <ExternalLink className="w-3 h-3" />
           Open in Editor
         </button>

--- a/dashboard-app/frontend/src/components/cosmic-view/CosmicView.tsx
+++ b/dashboard-app/frontend/src/components/cosmic-view/CosmicView.tsx
@@ -12,6 +12,7 @@ import type { CosmicViewProps } from './types'
 export function CosmicView({
   hotspots,
   onSelect,
+  onOpenInEditor,
   selectedDomain,
   onDomainFilter,
 }: CosmicViewProps) {
@@ -54,7 +55,7 @@ export function CosmicView({
   // No data state
   if (cosmicData.totalBodies === 0) {
     return (
-      <div className="fixed inset-0 flex items-center justify-center bg-slate-900/30">
+      <div className="relative h-[600px] flex items-center justify-center bg-slate-900/30 rounded-lg border border-slate-700">
         <div className="text-center">
           <div className="mb-2 text-4xl">🌌</div>
           <p className="text-slate-400">No hotspots to visualize</p>
@@ -67,8 +68,8 @@ export function CosmicView({
   }
 
   return (
-    <div className="fixed inset-0 flex flex-col">
-      {/* Full screen 3D canvas */}
+    <div className="relative h-[600px] flex flex-col rounded-lg overflow-hidden border border-slate-700">
+      {/* 3D canvas container */}
       <div className="relative flex-1">
         <CosmicCanvas cosmicData={cosmicData} onSelectBody={handleSelectBody} />
 
@@ -106,7 +107,11 @@ export function CosmicView({
       {selectedBodyData && (
         <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-slate-900 to-transparent">
           <div className="max-w-4xl mx-auto">
-            <CosmicDetailPanel body={selectedBodyData} onClose={clearSelection} />
+            <CosmicDetailPanel
+              body={selectedBodyData}
+              onClose={clearSelection}
+              onOpenInEditor={onOpenInEditor}
+            />
           </div>
         </div>
       )}

--- a/dashboard-app/frontend/src/components/cosmic-view/HotspotVisualization.tsx
+++ b/dashboard-app/frontend/src/components/cosmic-view/HotspotVisualization.tsx
@@ -1,24 +1,62 @@
+import { Suspense, lazy } from 'react'
+import { useCosmicStore } from '../../stores'
 import HotspotTreemap from '../hotspot-treemap'
+import { ViewToggle } from './ViewToggle'
 import type { HotspotVisualizationProps } from './types'
+
+// Lazy load the cosmic view to avoid loading Three.js when not needed
+const CosmicView = lazy(() => import('./CosmicView'))
+
+// Loading fallback for the cosmic view
+function CosmicLoadingFallback() {
+  return (
+    <div className="flex h-[500px] items-center justify-center rounded-lg border border-slate-700 bg-slate-900/50">
+      <div className="text-center">
+        <div className="mb-4 h-8 w-8 animate-spin rounded-full border-2 border-slate-600 border-t-amber-500 mx-auto" />
+        <p className="text-sm text-slate-400">Loading cosmic view...</p>
+      </div>
+    </div>
+  )
+}
 
 export function HotspotVisualization({
   hotspots,
   onSelect,
+  onOpenInEditor,
   selectedDomain,
   onDomainFilter,
 }: HotspotVisualizationProps) {
+  const viewMode = useCosmicStore((s) => s.viewMode)
+
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <h2 className="text-lg font-semibold text-white">Hotspots</h2>
+      {/* Header with toggle */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-white">Hotspots</h2>
+        <ViewToggle />
+      </div>
 
-      {/* Treemap view */}
-      <HotspotTreemap
-        hotspots={hotspots}
-        onSelect={onSelect}
-        selectedDomain={selectedDomain}
-        onDomainFilter={onDomainFilter}
-      />
+      {/* View container */}
+      <div className="relative">
+        {viewMode === 'grid' ? (
+          <HotspotTreemap
+            hotspots={hotspots}
+            onSelect={onSelect}
+            selectedDomain={selectedDomain}
+            onDomainFilter={onDomainFilter}
+          />
+        ) : (
+          <Suspense fallback={<CosmicLoadingFallback />}>
+            <CosmicView
+              hotspots={hotspots}
+              onSelect={onSelect}
+              onOpenInEditor={onOpenInEditor}
+              selectedDomain={selectedDomain}
+              onDomainFilter={onDomainFilter}
+            />
+          </Suspense>
+        )}
+      </div>
     </div>
   )
 }

--- a/dashboard-app/frontend/src/components/cosmic-view/types.ts
+++ b/dashboard-app/frontend/src/components/cosmic-view/types.ts
@@ -133,6 +133,7 @@ export interface CosmicHierarchy {
 export interface CosmicViewProps {
   hotspots: ApiHotspot[]
   onSelect: (path: string, line?: number) => void
+  onOpenInEditor?: (path: string, line?: number) => void
   selectedDomain: string | null
   onDomainFilter: (domain: string | null) => void
 }
@@ -143,6 +144,7 @@ export interface CosmicViewProps {
 export interface HotspotVisualizationProps {
   hotspots: ApiHotspot[]
   onSelect: (path: string, line?: number) => void
+  onOpenInEditor?: (path: string, line?: number) => void
   selectedDomain: string | null
   onDomainFilter: (domain: string | null) => void
 }


### PR DESCRIPTION
## Summary

This PR addresses three UX issues in the Cosmic view:

### 1. Contained Cosmic View
- **Problem:** Cosmic view used `fixed inset-0` covering the entire screen, blocking the header navigation, sidebar (Alerts panel), and other UI elements
- **Fix:** Changed to `relative h-[600px]` contained within the grid layout with rounded borders
- **Result:** All surrounding UI elements remain clickable when Cosmic view is active

### 2. Zoom Persistence
- **Problem:** User zoom/pan would immediately reset because `useFrame` continuously forced the camera back to default distance
- **Fix:** Added `isAnimating` flag that only allows auto-animation for 1.5 seconds after selection changes
- **Result:** User can freely zoom and pan, state persists until next selection

### 3. Editor Opens Only on Explicit Action
- **Problem:** Clicking any planet immediately opened the file in external editor
- **Fix:** Separated `onSelect` (selection only) from `onOpenInEditor` (editor action), wired up the "Open in Editor" button
- **Result:** Click planet → opens info card only; click "Open in Editor" button → opens file

## Files Changed
| File | Change |
|------|--------|
| `CosmicView.tsx` | Contained layout, pass onOpenInEditor prop |
| `CameraController.tsx` | Animation timing control with isAnimating ref |
| `CosmicDetailPanel.tsx` | Wire up Open in Editor button onClick |
| `types.ts` | Add onOpenInEditor to props interfaces |
| `HotspotVisualization.tsx` | Pass through onOpenInEditor |
| `App.tsx` | Separate onSelect from onOpenInEditor |

## Testing
- Verified header/sidebar remain clickable in Cosmic view
- Verified zoom/pan persists after user interaction
- Verified planets only open info card on click
- Verified "Open in Editor" button opens file