### PR TITLE
fix(install): copy missing hooks and query dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -142,18 +142,26 @@ echo -e "${YELLOW}[Step 3/5]${NC} Installing core components..."
 SRC_DIR="$SCRIPT_DIR"
 
 # Copy core files
-cp "$SRC_DIR/query/query.py" "$EMERGENT_LEARNING_DIR/query/query.py"
-cp "$SRC_DIR/query/models.py" "$EMERGENT_LEARNING_DIR/query/models.py" 2>/dev/null || true
+# Copy all query Python files (not just query.py and models.py)
+cp "$SRC_DIR/query/"*.py "$EMERGENT_LEARNING_DIR/query/" 2>/dev/null || true
+# Copy queries subdirectory
+cp -r "$SRC_DIR/query/queries" "$EMERGENT_LEARNING_DIR/query/" 2>/dev/null || true
 cp "$SRC_DIR/templates/golden-rules.md" "$EMERGENT_LEARNING_DIR/memory/golden-rules.md"
 cp "$SRC_DIR/templates/init_db.sql" "$EMERGENT_LEARNING_DIR/memory/init_db.sql"
 echo -e "  ${GREEN}Copied query system${NC}"
 
-# Install core Python dependencies
-pip install -q peewee 2>&1 || pip3 install -q peewee 2>&1
-echo -e "  ${GREEN}Installed Python dependencies (peewee)${NC}"
+# Install core Python dependencies from requirements.txt
+if [ -f "$SRC_DIR/requirements.txt" ]; then
+    pip install -q -r "$SRC_DIR/requirements.txt" 2>&1 || pip3 install -q -r "$SRC_DIR/requirements.txt" 2>&1
+    echo -e "  ${GREEN}Installed Python dependencies${NC}"
+else
+    pip install -q peewee 2>&1 || pip3 install -q peewee 2>&1
+    echo -e "  ${GREEN}Installed Python dependencies (peewee)${NC}"
+fi
 
 # Copy hooks
 # Hooks stay in emergent-learning directory (not copied to ~/.claude/hooks/)
+cp -r "$SRC_DIR/hooks" "$EMERGENT_LEARNING_DIR/" 2>/dev/null || true
 echo -e "  ${GREEN}Copied learning hooks${NC}"
 
 # Copy scripts


### PR DESCRIPTION
## Problem

The install script was not copying critical files needed for ELF to function, causing validation failures with `ModuleNotFoundError`.

### Issues Found

1. **Missing Hooks Directory**
   - Line 156 printed "Copied learning hooks" but never executed a copy command
   - All hooks were missing from `~/.claude/emergent-learning/hooks/`
   - This caused hook errors during tool execution

2. **Missing Query Dependencies**
   - Only `query.py` and `models.py` were copied
   - Missing modules: `exceptions.py`, `utils.py`, `validators.py`, `formatters.py`, `setup.py`, `cli.py`, `core.py`
   - Missing `queries/` subdirectory with all query mixins

3. **Incomplete Python Dependencies**
   - Hardcoded `peewee` installation
   - But `requirements.txt` specifies `peewee-aio[aiosqlite]` and `aiofiles`

## Solution

- Copy all `*.py` files from `query/` directory
- Copy `query/queries` subdirectory
- Copy `hooks/` directory to `emergent-learning/`
- Use `requirements.txt` if available, fallback to `peewee`

## Testing

Tested on macOS:
- ✅ Database validation passes
- ✅ `query.py --context` works correctly
- ✅ Hooks are accessible and functional
- ✅ No more ModuleNotFoundError

## Files Changed

- `install.sh` - Fixed core installation to copy all required files